### PR TITLE
Bug fixes and a little bit more :)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -22,11 +22,15 @@ CLI.prototype.configure = function () {
 };
 
 CLI.prototype.backlog = function (options) {
-  var self = this, opts = {
-    projectName: options.project || this.config.product,
-    pagesize: options.all ? 100 : 20,
-    tag: options.tag
-  };
+  var self = this, 
+      team = this.config.team,
+      project = options.project || this.config.project,
+      projectName = project || team,
+      opts = {
+        projectName: project || team,
+        pagesize: options.all ? 100 : 20,
+        tag: options.tag
+      };
   this.ralio.backlog(opts, function (error, stories) {
     self.errors(error);
     if (!options.all) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -45,8 +45,10 @@ CLI.prototype.backlog = function (options) {
 
 CLI.prototype.sprint = function (options) {
   var self = this,
-      team = options.project || this.config.team;
-  this.ralio.sprint(team, function (error, stories) {
+      team = options.group || this.config.team,
+      project = options.project || this.config.project,
+      projectName = project || team;
+  this.ralio.sprint(projectName, function (error, stories) {
     self.errors(error);
     stories.forEach(function (story) {
       if (story.ScheduleState != 'Accepted' || options.accepted) {

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -47,6 +47,9 @@ Ralio.prototype.bulk = function (query, callback) {
     if (error !== null) {
       callback(error);
     }
+    else if (response.statusCode === 401) {
+      callback("Authentication failed!".red);
+    }
     else if (response.statusCode !== 200) {
       callback(response.body);
     }

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -189,8 +189,14 @@ Ralio.prototype.setTaskState = function (task_id, options, callback) {
       callback(error);
     }
     else {
-      var user = data.user;
-      var task = data.task.Results[0];
+      
+      var user = data.user,
+          task = data.task.Results[0];
+
+      if (data.task.TotalResultCount === 0){
+        callback("TASK NOT FOUND!");
+      }
+      
       var update = {
         Task: {
           _ref: task._ref,

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -197,7 +197,7 @@ Ralio.prototype.setTaskState = function (task_id, options, callback) {
           task = data.task.Results[0];
 
       if (data.task.TotalResultCount === 0){
-        callback("TASK NOT FOUND!");
+        callback("TASK NOT FOUND!".red);
       }
       
       var update = {
@@ -353,4 +353,3 @@ Ralio.prototype.orderTasks = function (tasks) {
 }
 
 module.exports = Ralio;
-


### PR DESCRIPTION
The task._ref instruction throws an error when the typed task doesn't exist.
/usr/local/share/npm/lib/node_modules/ralio/lib/ralio.js:196
          _ref: task._ref,
                    ^
TypeError: Cannot read property '_ref' of undefined
    at Ralio.setTaskState (/usr/local/share/npm/lib/node_modules/ralio/lib/ralio.js:196:21)
    at Request.Ralio.bulk [as _callback](/usr/local/share/npm/lib/node_modules/ralio/lib/ralio.js:54:7)
    at Request.init.self.callback (/usr/local/share/npm/lib/node_modules/ralio/node_modules/request/main.js:120:22)
    at Request.EventEmitter.emit (events.js:99:17)
    at Request.<anonymous> (/usr/local/share/npm/lib/node_modules/ralio/node_modules/request/main.js:555:16)
    at Request.EventEmitter.emit (events.js:96:17)
    at IncomingMessage.Request.start.self.req.self.httpModule.request.buffer (/usr/local/share/npm/lib/node_modules/ralio/node_modules/request/main.js:517:14)
    at IncomingMessage.EventEmitter.emit (events.js:126:20)
    at IncomingMessage._emitEnd (http.js:366:10)
    at HTTPParser.parserOnMessageComplete [as onMessageComplete](http.js:149:23)
