### PR TITLE
Allow the Rally host to be specified through a command line switch.

### DIFF
--- a/bin/ralio
+++ b/bin/ralio
@@ -3,7 +3,10 @@
 var program = require('commander'),
     CLI = require('../lib/cli');
 var package = require('../package.json');
-program.version(package.version);
+
+program
+  .version(package.version)
+  .option('-H, --host [host]','Rally host that will be used for all commands')
 
 program
   .command('backlog')
@@ -11,7 +14,7 @@ program
   .option('-a, --all', 'Show all stories (instead of just the top 20)')
   .option('-t, --tag [tag]', 'Show stories tagged with [tag]')
   .option('-p, --project [project]', 'Show backlog stories for project [project]')
-  .action(function (opts) { new CLI().backlog(opts) });
+  .action(function (opts) { new CLI(opts.parent.host).backlog(opts) });
 
 program
   .command('sprint')
@@ -20,23 +23,23 @@ program
   .option('-f, --find [term]', 'Find stories that matches with the term [term]')
   .option('-a, --accepted', 'Show accepted stories')
   .option('-p, --project [project]', 'Show sprint stories for project [project]')
-  .action(function (opts) { new CLI().sprint(opts) });
+  .action(function (opts) { new CLI(opts.parent.host).sprint(opts) });
 
 program
   .command('show <item>')
   .description('Show related information for an individual story, defect or task')
-  .action(function (item) { new CLI().show(item) });
+  .action(function (item, opts) { new CLI(opts.host).show(item) });
 
 program
   .command('open <item>')
   .description('Open a story, defect or task in a web browser')
-  .action(function (item) { new CLI().open(item) });
+  .action(function (item, opts) { new CLI(opts.parent.host).open(item) });
 
 program
   .command('start <item>')
   .option('-p, --pair [pair]', 'How\'s pair [pair] programming with you')
   .description('Set a task, defect or story state to in-progress and assign it to you')
-  .action(function (item, opts) { new CLI().start(item, opts) });
+  .action(function (item, opts) { new CLI(opts.parent.host).start(item, opts) });
 
 program
   .command('finish <item>')
@@ -44,32 +47,32 @@ program
   .option('-r, --resolution [resolution]', 'Set defect\'s resolution.')
   .option('-p, --pair [pair]', 'How\'s pair [pair] programming with you')
   .description('Set a task, defect or story state to completed and assign it to you')
-  .action(function (item, opts) { new CLI().finish(item, opts) });
+  .action(function (item, opts) { new CLI(opts.parent.host).finish(item, opts) });
 
 program
   .command('abandon <item>')
   .description('Set a task, defect or story state to defined and clear the owner')
-  .action(function (item) { new CLI().abandon(item) });
+  .action(function (item, opts) { new CLI(opts.parent.host).abandon(item) });
 
 program
   .command('block <item>')
   .description('Set a task, defect or story state to blocked')
-  .action(function (item) { new CLI().block(item) });
+  .action(function (item, opts) { new CLI(opts.parent.host).block(item) });
 
 program
   .command('unblock <item>')
   .description('Set a task, defect or story state to unblocked')
-  .action(function (item) { new CLI().unblock(item) });
+  .action(function (item, opts) { new CLI(opts.parent.host).unblock(item) });
 
 program
   .command('current')
   .description('Show your current tasks and stories')
-  .action(function () { new CLI().current() });
+  .action(function (opts) { new CLI(opts.parent.host).current() });
 
 program
   .command('point <story> <points>')
   .description('Set the points for a story or defect')
-  .action(function (story, points) { new CLI().point(story, parseInt(points, 10)) });
+  .action(function (story, points, opts) { new CLI(opts.parent.host).point(story, parseInt(points, 10)) });
 
 program
   .command('task <option> <target>')
@@ -80,7 +83,7 @@ program
   .option('-n, --name [name]', 'Name [name] of the task')
   .option('-t, --tags [tags]', 'List of [tags] separated by comma.')
   .option('-p, --project [project]', 'Create/delete a task from a specific project [project]')
-  .action(function (opts, option, target) { new CLI().task(opts, option, target) });
+  .action(function (opts, option, target) { new CLI(opts.parent.host).task(opts, option, target) });
 
 program
   .command('configure')
@@ -113,6 +116,10 @@ program
       });
     });
   });
+
+program
+  .command('*')
+  .action(function (opts) { console.log('Command not found! Try running ralio --help'.red); })
 
 program.on('--help', function(){
   console.log('  Usage Examples');
@@ -159,9 +166,6 @@ program.on('--help', function(){
   console.log('    $ ralio finish DE1234 --rootcause "Code Design/Error" --resolution "Code Change" --pair "Mark"');
   console.log('');
 });
-
-if(typeof program._events[process.argv[2]] === "undefined" && process.argv[2] !== "-V" && process.argv[2] !== "--version")
-  console.log('Command not found! Try running ralio --help'.red);
 
 program.parse(process.argv);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,9 +6,10 @@ var path = require('path'),
     _ = require('underscore'),
     Ralio = require('./ralio');
 
-function CLI() {
+function CLI(hostname) {
+  this.hostname = hostname || 'https://rally1.rallydev.com/';
   this.configure();
-  this.ralio = new Ralio(this.config.username, this.config.password, this.config.project, this.config.team);
+  this.ralio = new Ralio(this.hostname, this.config.username, this.config.password, this.config.project, this.config.team);
 }
 
 CLI.prototype.configure = function () {
@@ -146,7 +147,7 @@ CLI.prototype.open = function (story) {
       }
       child_process.exec(
         openCommand + ' ' +
-        'https://rally1.rallydev.com/#/' +
+        self.hostname + '#/' +       
         story.Project.ObjectID +
         'd/detail/' + story_type +
         '/' + story.ObjectID);

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -1,9 +1,11 @@
 var url = require('url'),
     querystring = require('querystring'),
     request = require('request'),
+    url = require('url'),
     _ = require('underscore');
 
-function Ralio(username, password, project, team) {
+function Ralio(hostname, username, password, project, team) {
+  this.hostname = hostname;
   this.username = username;
   this.password = password;
   this.project = project;
@@ -13,11 +15,14 @@ function Ralio(username, password, project, team) {
 Ralio.test = false;
 
 Ralio.prototype.bulkUrl = function (options) {
-  options = options || {};
+  var options = options || {},
+    rally_url = url.parse(this.hostname);
+
   return url.format({
-    protocol: options.protocol ? options.protocol : 'https',
+    protocol: rally_url.protocol,
     auth: this.username + ':' + this.password,
-    hostname: 'rally1.rallydev.com',
+    hostname: rally_url.hostname,
+    port: rally_url.port,
     pathname: options.pathname ? options.pathname : '/slm/webservice/1.36/adhoc.js'
   });
 };
@@ -52,8 +57,7 @@ Ralio.prototype.request = function(options, callback) {
   request(options, function (error, response, data) {
     if (error !== null) {
       callback(error);
-    }
-    else if (response.statusCode === 401) {
+    } else if (response.statusCode === 401) {
       var error = "Authentication failed! Check your ~/.raliorc file!";
       callback(Ralio.test ? error : error.red);
     } else if (response.statusCode !== 200) {

--- a/test/ralio_test.js
+++ b/test/ralio_test.js
@@ -16,7 +16,7 @@ describe('Ralio', function () {
   });
 
   beforeEach(function () {
-    this.ralio = new Ralio('user1', 'password1');
+    this.ralio = new Ralio(RALLY_SERVER, 'user1', 'password1');
   });
 
   afterEach(function () {


### PR DESCRIPTION
Not all users of rally use rally1.rallydev.com. I changed the code to allow the Rally host to be configured through a command line option.

I decided not to use a config file property, because most of the time people will want to use rally1.rallydev.com. But... at Rally we have tests systems that we sometimes want to access with ralio. A command line option seemed like the best choice.
