### PR TITLE
added edit command that uses the system EDITOR

### DIFF
--- a/bin/ralio
+++ b/bin/ralio
@@ -31,6 +31,11 @@ program
   .action(function (item, opts) { new CLI(opts.host).show(item) });
 
 program
+  .command('edit <item> <field>')
+  .description('Edit a field of an individual story, defect or task in the system EDITOR')
+  .action(function (item, field, opts) { new CLI(opts.parent.host).edit(item, field) });
+
+program
   .command('open <item>')
   .description('Open a story, defect or task in a web browser')
   .action(function (item, opts) { new CLI(opts.parent.host).open(item) });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,6 +4,7 @@ var path = require('path'),
     temp = require('temp'),
     colors = require('colors'),
     _ = require('underscore'),
+    html = require("html"),
     Ralio = require('./ralio');
 
 function CLI(hostname) {
@@ -89,6 +90,70 @@ CLI.prototype.current = function () {
     self.saveQuickIDs();
   });
 };
+
+CLI.prototype.preFormatHtml = function(html_in) {
+  var formatted = html.prettyPrint(html_in, {indent_size: 2});
+  return formatted;
+};
+
+CLI.prototype.ATTRIBUTE_OPTIONS = {
+  supported: [
+    {type: "STRING", suffix: '.txt'},
+    {type: "BOOLEAN", suffix: '.txt'},
+    {type: "INTEGER", suffix: '.txt'},
+    {type: "TEXT", suffix: '.html', preformat: CLI.prototype.preFormatHtml}
+    ],
+
+  forType: function (type) {
+    return _.find(this.supported, function(ok_type){return ok_type.type == type});
+  }
+};
+
+CLI.prototype.edit = function (formattedID, field) {
+  var self = this;
+
+  this.ralio.artifact(formattedID, {fetch: field}, {typeDefinition: true}, function (err, artifact) {
+    self.errors(err);
+
+    if (typeof artifact[field] == 'undefined') {
+      err = 'Field ' + field + ' not found.';
+    }
+
+    var fieldType = _.find(artifact._typeDefinition.Attributes, function(attr){ return attr.ElementName == field }).AttributeType;
+    var fieldOpts = self.ATTRIBUTE_OPTIONS.forType(fieldType);
+    if (typeof fieldOpts == 'undefined') {
+      err = 'Field ' + field + ' is not a type suported by this tool. [' + fieldType + ']';
+    }
+    var suffix = fieldOpts.suffix || '.txt';
+
+    self.errors(err);
+
+    var old_value = artifact[field];
+
+    if (typeof fieldOpts.preformat === 'function') {
+      old_value = fieldOpts.preformat(old_value);
+    }
+
+    self.ralio.editor(old_value, {suffix: suffix}, function (result) {
+      if (false == result.success) {
+        console.error(('EDITOR returned error.  Exit code: ' +  result.editor.exit_code + ', Exit signal: ' + result.editor.exit_signal).red);
+        return;
+      }
+
+      if (old_value !== result.value) {
+        var updates = {};
+        updates[field] = result.value;
+
+        self.ralio.updateArtifact(artifact, updates, function (err) {
+          if (err !== null){
+            console.error(('Error updating ' + formattedID + '.  Err: ' + err).red);
+          }
+        });
+      }
+    });
+  });
+};
+
 
 CLI.prototype.show = function (story) {
   var self = this;
@@ -266,7 +331,7 @@ CLI.prototype.printTaskLine = function (task, options) {
   var defaults = {quickid: true, tab: true, tags: true, points: false};
   options = _.extend({}, defaults, options || {});
   
-  var taskState = TASKSTATES[task.ScheduleState || task.State],
+  var taskState = TASKSTATES[task.ScheduleState || task.State] || '.',
       owner = task.Owner !== null ? "❙ " + task.Owner._refObjectName : '',
       fields = [],
       pair = (task.Pair && task.Pair !== "" && task.Pair !== "true" && task.Pair !== null) ? "& " + task.Pair : null;

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -1,8 +1,10 @@
 var url = require('url'),
     querystring = require('querystring'),
     request = require('request'),
-    url = require('url'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    temp = require('temp'),
+    editor = require('editor'),
+    fs = require('fs');
 
 function Ralio(hostname, username, password, project, team) {
   this.hostname = hostname;
@@ -14,18 +16,117 @@ function Ralio(hostname, username, password, project, team) {
 
 Ralio.test = false;
 
-Ralio.prototype.bulkUrl = function (options) {
-  var options = options || {},
-    rally_url = url.parse(this.hostname);
+Ralio.prototype.prefixes = function (workspaceId) {
+  // Hard coded for now - we should load these from WSAPI because they're configurable per workspace
+  return {
+    'US': 'hierarchicalrequirement',
+    'S' : 'hierarchicalrequirement',
+    'TA': 'task',
+    'DE': 'defect'
+  };
+}
 
+Ralio.prototype.prefixOf = function (formattedID) {
+  return formattedID.match(/^[^0-9]+/)[0].toUpperCase();
+}
+
+Ralio.prototype.rallyWsapiUrl = function (type, query, options) {
+  var rally_url = url.parse(this.hostname);
+
+  options = options || {};
+  query = query || {};
   return url.format({
     protocol: rally_url.protocol,
     auth: this.username + ':' + this.password,
     hostname: rally_url.hostname,
     port: rally_url.port,
-    pathname: options.pathname ? options.pathname : '/slm/webservice/1.36/adhoc.js'
+    pathname: options.pathname ? options.pathname : '/slm/webservice/1.42/' + type + '.js',
+    query: query
   });
+}
+
+Ralio.prototype.bulkUrl = function (options) {
+  return this.rallyWsapiUrl('adhoc', {}, options);
 };
+
+Ralio.prototype.artifactUrl = function (formattedID, query) {
+  var type = this.prefixes()[this.prefixOf(formattedID)];
+  return this.rallyWsapiUrl(type, query);
+};
+
+Ralio.prototype.typedefUrl = function (query) {
+  return this.rallyWsapiUrl('typedefinition', query);
+};
+
+Ralio.prototype.rallyWsapiRequest = function (options) {
+  return _.extend({
+    method: 'GET',
+    json: {},
+    strictSSL: !Ralio.test
+    }, options);
+}
+
+Ralio.prototype.domainObject = function (displayName, url, callback) {
+  var self = this;
+  var req = this.rallyWsapiRequest({url: url});
+
+  this.request(req, function (err, results){
+    if (err !== null) {
+      callback(err);
+    } else if (results.QueryResult.TotalResultCount > 1) {
+      callback('Query for single object [' + displayName + '] returned multiple results.  Errors: ' + results.QueryResult.Errors);
+    } else if (results.QueryResult.TotalResultCount == 0) {
+      callback(displayName + ' not found.  Errors: ' + results.QueryResult.Errors);
+    } else {
+      var result = results.QueryResult.Results[0];
+      result._QueryResult = results.QueryResult;
+      callback(err, result);
+    }
+  });
+}
+
+Ralio.prototype.typedef = function (type, query, callback) {
+  query = _.extend({
+    query: "(TypePath = \"" + type + "\")",
+    fetch: true,
+    pagesize: 1,
+    }, query);
+
+  var url = this.typedefUrl(query);
+  this.domainObject('TypeDef [' + type + ']', url, callback);
+}
+
+Ralio.prototype.artifact = function (formattedID, query, opts, callback) {
+  var self = this;
+  query = _.extend({
+    query: "(FormattedID = " + formattedID + ")",
+    fetch: "FormattedID",
+    typeDefinition: false,
+    pagesize: 1
+    }, query);
+
+  opts = _.extend({
+    typeDefinition: false
+    }, opts);
+
+  var url = this.artifactUrl(formattedID, query);
+
+  this.domainObject(formattedID, url, function (err, result){
+    if (err !== null) {
+      callback(err);
+    } else {
+      if (opts.typeDefinition) {
+        self.typedef(result._type, {}, function(err, typedef) {
+          result._typeDefinition = typedef;
+
+          callback(err, result);
+        });
+      } else {
+        callback(err, result);
+      }
+    }
+  });
+}
 
 Ralio.prototype.date = function () {
   return new Date().toISOString().slice(0, 10);
@@ -67,6 +168,12 @@ Ralio.prototype.request = function(options, callback) {
     }
   });
 };
+
+Ralio.prototype.updateArtifact = function (artifact, updates, callback) {
+  var up={};
+  up[artifact._type] = updates;
+  this.update(artifact._ref, up, callback);
+}
 
 Ralio.prototype.update = function (ref, changes, callback) {
   ref = url.parse(ref);
@@ -134,11 +241,11 @@ Ralio.prototype.sprint = function (projectName, options, callback) {
   // 4 Filters: ((Project.Name = "Hokage") AND ((Iteration.StartDate <= "2013-03-07") AND ((Iteration.EndDate >= "2013-03-07") AND (Project.Name = "Hokage"))))
 
   var self = this,
-      d = this.date(),  
+      d = this.date(),
       fetch = 'Name,FormattedID,Rank,PlanEstimate,ScheduleState,Tasks,Tags,Pair,Defects,State,Owner,TaskIndex,Blocked',
       query_string = '((Project.Name = "' + projectName + '") AND ((Iteration.StartDate <= "' + d + '") AND (Iteration.EndDate >= "' + d + '")))';
 
-  if(options.find && options.find !== true) 
+  if(options.find && options.find !== true)
     query_string = '((Project.Name = "' + projectName + '") AND ((Iteration.StartDate <= "' + d + '") AND ((Iteration.EndDate >= "' + d + '") AND (Name contains "'+ options.find + '"))))';
 
   var query = {
@@ -184,7 +291,7 @@ Ralio.prototype.story = function (storyID, callback) {
       callback(error);
     } else {
       var data = data.hierarchicalrequirement || data.defect || data.task;
-      
+
       if(data.TotalResultCount === 0){
         callback(storyID + " Not Found!")
       }
@@ -194,7 +301,7 @@ Ralio.prototype.story = function (storyID, callback) {
       if (story !== null) {
         story.Tasks = self.orderTasks(story.Defects ? story.Tasks.concat(story.Defects) : story.Tasks);
       }
-      
+
       callback(null, story);
     }
   });
@@ -269,9 +376,9 @@ Ralio.prototype.setTaskState = function (task_id, options, callback) {
       if (options.state) {
 
         if (type === "US" || type === "DE") {
-          taskObject.ScheduleState = options.state; 
+          taskObject.ScheduleState = options.state;
         } else {
-          taskObject.State = options.state; 
+          taskObject.State = options.state;
         }
 
         if (options.state === "In-Progress" || options.state === "Defined") {
@@ -282,14 +389,14 @@ Ralio.prototype.setTaskState = function (task_id, options, callback) {
             taskObject.State = "Open";
           }
         }
-      
+
         if (options.state === 'Completed') {
           taskObject.ToDo = 0.0;
 
           if (type === "DE") {
             taskObject.State = "Fixed";
-          } 
-          
+          }
+
         }
       }
 
@@ -391,7 +498,7 @@ Ralio.prototype.point = function (storyID, points, callback) {
 
       var update = {},
           data = data.hierarchicalrequirement || data.defect;
-      
+
       if(data.TotalResultCount === 0)
         callback(storyID + " Not Found!")
 
@@ -406,13 +513,13 @@ Ralio.prototype.point = function (storyID, points, callback) {
           _ref: task._ref,
           PlanEstimate: points
         };
-      } 
+      }
 
       self.update(task._ref, update, function (error) {
         if (error) {
           callback(error);
         } else {
-        
+
           self.bulk(query, function (error, data) {
             if (error) {
               callback(error);
@@ -420,7 +527,7 @@ Ralio.prototype.point = function (storyID, points, callback) {
               callback(null, (data.hierarchicalrequirement || data.defect).Results[0]);
             }
           });
-         
+
         }
       });
     }
@@ -449,7 +556,7 @@ Ralio.prototype.createTask = function (projectName, storyID, taskName, tags, cal
         var story = data._ref,
             project = data.Project._ref,
             new_task = {"Task":{
-                "Name": taskName, 
+                "Name": taskName,
                 "Project": project,
                 "WorkProduct": story,
                 "ToDo": 1.0,
@@ -459,7 +566,7 @@ Ralio.prototype.createTask = function (projectName, storyID, taskName, tags, cal
             };
 
         var options = {
-          url: self.bulkUrl({"pathname":"/slm/webservice/1.36/task/create.js"}),
+          url: self.bulkUrl({"pathname":"/slm/webservice/1.42/task/create.js"}),
           method: 'POST',
           json: new_task,
           strictSSL: !Ralio.test
@@ -478,11 +585,11 @@ Ralio.prototype.deleteTask = function (projectName, storyID, callback) {
   var self = this;
 
   self.getTask(storyID, function(error, task) {
-    if (error || typeof task !== "object") 
+    if (error || typeof task !== "object")
       return callback(error);
 
     var deletePath = url.parse(task._ref).pathname;
-   
+
     var options = {
           url: self.bulkUrl({"pathname": deletePath}),
           method: 'DELETE',
@@ -529,7 +636,7 @@ Ralio.prototype.getTags = function (tags, callback) {
         callback(error);
       } else {
         callback(null, data);
-      }  
+      }
     });
   }
 };
@@ -558,6 +665,46 @@ Ralio.prototype.orderStories = function (stories) {
 
 Ralio.prototype.orderTasks = function (tasks) {
  return _.sortBy(tasks, function (t) { return t.TaskIndex });
+}
+
+Ralio.prototype.editor = function (contents, opts, callback) {
+  opts = opts || {};
+  var suffix = opts.suffix || '.txt';
+
+  var tmp_file = temp.open({suffix: suffix}, function (err, tmp_file) {
+    fs.write(tmp_file.fd, contents);
+    fs.close(tmp_file.fd, function(err) {
+      if (err && (typeof callback == 'function')) {
+        callback({success: false, err: err});
+        return;
+      }
+
+      editor(tmp_file.path, function (code, sig) {
+        if (0 == code) {
+          if (typeof callback == 'function') {
+            var new_contents = fs.readFileSync(tmp_file.path).toString().trimRight();
+            callback ({
+              success: true,
+              value: new_contents,
+              editor: {
+                exit_code: code,
+                exit_signal: sig
+              }});
+          }
+        } else {
+          if (typeof callback == 'function') {
+            callback ({
+              success: false,
+              editor: {
+                exit_code: code,
+                exit_signal: sig
+              }});
+          }
+        }
+      }); // editor(tmp_file.path)
+    }); //fs.close(tmp_file.fd)
+  }); // temp.open()
+
 }
 
 module.exports = Ralio;

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "node >= 0.7.0"
   ],
   "dependencies": {
+    "html": "0.0.7",
     "request": "2.9.203",
     "underscore": "1.3.3",
     "commander": "1.1.1",
     "colors": "0.6.0-1",
     "cli-table": "0.0.2",
-    "temp": "0.4.0"
+    "temp": "0.4.0",
+    "editor": "0.0.4"
   },
   "devDependencies": {
     "nock": "0.18.2",


### PR DESCRIPTION
1. adds $EDITOR and $VISUAL support
2. bumps WSAPI version to 1.42
3. adds some general purpose methods for retrieving a single artifact and typedef by FormattedID without using the adhoc.js endpoint (not supported in WSAPI 2.x).
