### PR TITLE
Add the ability to record timesheet entries for a task

### DIFF
--- a/bin/ralio
+++ b/bin/ralio
@@ -80,6 +80,11 @@ program
   .action(function (story, points, opts) { new CLI(opts.parent.host).point(story, parseInt(points, 10)) });
 
 program
+  .command('time <task> <hours>')
+  .description('Add a timesheet entry for a task')
+  .action(function (task, hours, opts) { new CLI(opts.parent.host).time(task, parseFloat(hours)) });
+
+program
   .command('task <option> <target>')
   .description('Allow you to create and delete story tasks.\n' + 
       'Available options <option> [create|delete].\n' + 
@@ -150,6 +155,10 @@ program.on('--help', function(){
   console.log('');
   console.log('    $ ralio point US1234');
   console.log('    $ ralio point DE1234');
+  console.log('');
+  console.log('  Adding a timesheet entry for a task:');
+  console.log('');
+  console.log('    $ ralio time TA1234 1.5');
   console.log('');
   console.log('  Viewing your current sprint story and/or tasks:');
   console.log('');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -276,6 +276,18 @@ CLI.prototype.point = function (story, points) {
   });
 };
 
+CLI.prototype.time = function (task, hours) {
+    var self = this;
+    this.ralio.time(this.fetchID(task), hours, function(error, data) {
+        self.errors(error);
+        if (data.Hours) {
+          console.log("Task " + task + " timesheet entry is now " + data.Hours + " hours.");
+        } else {
+          console.log(data);
+        }
+    });
+}
+
 CLI.prototype.task = function (option, story, opts) {
   var self = this,
       team = self.config.team,

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -155,6 +155,132 @@ Ralio.prototype.bulk = function (query, callback) {
   this.request(options, callback);
 };
 
+Ralio.prototype.time = function(taskID, hours, callback) {
+  var self = this,
+      type = taskID.slice(0,2).toUpperCase(),
+      query = {
+        fetch: 'Project,WorkProduct',
+        query: '((Project.Name = "' + this.project + '") AND (FormattedID = "' + taskID + '"))'
+      };
+
+  if (type === "TA") {
+    query = {task: query};
+  } else {
+    callback("Ralio can only put timesheet entries against a task (TA).");
+  }
+
+  var addTEV = function (project, item, hours) {
+    var date = new Date();
+    date.setUTCHours(0,0,0,0);
+    date = date.toISOString();
+    self.bulk({
+      timeentryvalue: {
+        fetch: 'Hours',
+        query: '((TimeEntryItem.Task.FormattedID = "' + taskID + '") AND (DateVal = "' + date + '"))'
+      }
+    }, function (error, data) {
+      if (error !== null) {
+        callback(error);
+      } else {
+        var value = data.timeentryvalue.Results;
+        if (value.length) {
+          self.update(value[0]._ref, {
+            TimeEntryValue: {
+              Hours: value[0].Hours + hours
+            }
+          }, function (error) {
+            if (error) {
+              callback(error);
+            } else {
+              callback(null, {
+                Hours: value[0].Hours + hours
+              });
+            }
+          });
+        } else {
+          var options = {
+            url: self.bulkUrl({"pathname":"/slm/webservice/1.36/timeentryvalue/create.js"}),
+            method: 'POST',
+            json: {"TimeEntryValue":{
+              "Project": project,
+              "TimeEntryItem": item,
+              "DateVal": date,
+              "Hours": hours
+            }},
+            strictSSL: !Ralio.test
+          };
+          self.request(options, function(error, data){
+            if (error !== null) {
+              callback(error);
+            } else if (data.CreateResult && data.CreateResult['Object']) {
+              callback(null, data.CreateResult['Object']);
+            } else {
+              callback("Failed to create a time entry.", data);
+            }
+          });
+        }
+      }
+    });
+  }
+
+  this.bulk(query, function (error, data) {
+    if (error !== null) {
+      callback(error);
+    } else {
+      var task = data.task.Results;
+      if (!task.length) {
+        callback("No task found with that ID.");
+      } else {
+        var project = task[0].Project._ref,
+            story   = task[0].WorkProduct._ref,
+            taskRef = task[0]._ref;
+
+        self.bulk({
+          timeentryitem: {
+            fetch: 'WeekStartDate',
+            query: '(Task.FormattedID = "' + taskID + '")'
+          }
+        }, function (error, data) {
+          if (error !== null) {
+            callback(error);
+          } else {
+            var item = data.timeentryitem.Results;
+            if (item.length) {
+              addTEV(project, item[0]._ref, hours);
+            } else {
+              var itemCreation = setInterval(function() {
+                var weekstart = new Date();
+                do {
+                  weekstart.setDate(weekstart.getDate() - 1);
+                } while (weekstart.getDay());
+                var options = {
+                  url: self.bulkUrl({"pathname":"/slm/webservice/1.36/timeentryitem/create.js"}),
+                  method: 'POST',
+                  json: {"TimeEntryItem":{
+                    "Project": project,
+                    "WorkProduct": story,
+                    "Task": taskRef,
+                    "WeekStartDate": weekstart.toISOString()
+                  }},
+                  strictSSL: !Ralio.test
+                };
+                self.request(options, function(error, data) {
+                  if (error !== null) {
+                    callback(error);
+                  } else {
+                    addTEV(project, data.CreateResult['Object']._ref, hours);
+                  }
+                });
+                clearInterval(itemCreation);
+              }, 300);
+            }
+          }
+        });
+      }
+    }
+  });
+}
+
 Ralio.prototype.request = function(options, callback) {
   request(options, function (error, response, data) {
     if (error !== null) {


### PR DESCRIPTION
Adds the `time` command, which builds a timesheet row for a task and its defect or story, if one doesn't already exist in this week, then puts the specified number of hours against it for today.
