### PR TITLE
Discussion reading and commenting support

### DIFF
--- a/bin/ralio
+++ b/bin/ralio
@@ -70,6 +70,12 @@ program
   .action(function (item, opts) { new CLI(opts.parent.host).unblock(item) });
 
 program
+  .command('discuss <item>')
+  .option('-a, --add <comment>', 'Add a comment to the discussion')
+  .description('View or add to the discussion items for a task, defect or story state')
+  .action(function (item, opts) { new CLI(opts.parent.host).discuss(item, opts); });
+
+program
   .command('current')
   .description('Show your current tasks and stories')
   .action(function (opts) { new CLI(opts.parent.host).current() });

--- a/bin/ralio
+++ b/bin/ralio
@@ -70,10 +70,12 @@ program
   .action(function (item, opts) { new CLI(opts.parent.host).unblock(item) });
 
 program
-  .command('discuss <item>')
-  .option('-a, --add <comment>', 'Add a comment to the discussion')
-  .description('View or add to the discussion items for a task, defect or story state')
-  .action(function (item, opts) { new CLI(opts.parent.host).discuss(item, opts); });
+  .command('discuss <option> <item> [message]')
+  .description('View or add to the discussion items for a task, defect or story state.\n' +
+      'Available options <option> [show|add].\n' +
+      'In case of <option> show, <item> is the task to show discussion for.\n' +
+      'In case of <option> add, <item> is the task to which to add a comment.')
+  .action(function (option, item, message, opts) { new CLI(opts.parent.host).discuss(option, item, message, opts); });
 
 program
   .command('current')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -245,12 +245,12 @@ CLI.prototype.finish = function (task, options) {
   });
 };
 
-CLI.prototype.discuss = function (item, options) {
+CLI.prototype.discuss = function (option, item, message, options) {
   var self = this,
       deferred = q.defer();
 
-  if (options.add) {
-    this.ralio.addComment(this.fetchID(item), options.add, function(error, data) {
+  if (option == 'add') {
+    this.ralio.addComment(this.fetchID(item), message, function(error, data) {
       self.errors(error);
       if (!data.PostNumber) {
         deferred.reject();
@@ -258,8 +258,10 @@ CLI.prototype.discuss = function (item, options) {
         deferred.resolve();
       }
     });
-  } else {
+  } else if (option == 'show') {
     deferred.resolve();
+  } else {
+    return self.errors('Option to discuss command must be one of: show, add.');
   }
 
   deferred.promise.then(function() {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,6 @@
 var path = require('path'),
     fs = require('fs'),
+    q = require('q'),
     child_process = require('child_process'),
     temp = require('temp'),
     colors = require('colors'),
@@ -244,6 +245,34 @@ CLI.prototype.finish = function (task, options) {
   });
 };
 
+CLI.prototype.discuss = function (item, options) {
+  var self = this,
+      deferred = q.defer();
+
+  if (options.add) {
+    this.ralio.addComment(this.fetchID(item), options.add, function(error, data) {
+      self.errors(error);
+      if (!data.PostNumber) {
+        deferred.reject();
+      } else {
+        deferred.resolve();
+      }
+    });
+  } else {
+    deferred.resolve();
+  }
+
+  deferred.promise.then(function() {
+    self.ralio.comments(self.fetchID(item), function (error, comments) {
+      self.errors(error);
+      self.printTaskLine(comments.artifact, {quickid: false, tab: false});
+      for (var i in comments.comments) {
+        self.printDiscussionLine(comments.comments[i]);
+      }
+    });
+  });
+}
+
 CLI.prototype.abandon = function (task) {
   var self = this;
   this.ralio.setTaskState(this.fetchID(task), {state: 'Defined', own: false, blocked: false, pair: ""}, function (error, task) {
@@ -379,6 +408,26 @@ CLI.prototype.printTaskLine = function (task, options) {
     var tags = _.map(_.compact(task.Tags), function (t) { return t.Name }).join(', ');
     fields.push(this.isInProgress(task) ? tags.magenta : tags.grey);
   }
+
+  console.log(fields.join(' '));
+};
+
+CLI.prototype.printDiscussionLine = function (comment, options) {
+  var defaults = {number: true, tab: true};
+  options = _.extend({}, defaults, options || {});
+
+  var owner = comment.User !== null ? comment.User._refObjectName + " ❙" : '',
+      post = '' + (comment.PostNumber + 1),
+      fields = [];
+
+  if (options.tab)
+    fields.push(' ');
+
+  if (options.number)
+    fields.push(post.yellow);
+
+  fields.push(owner.blue);
+  fields.push(comment.Text);
 
   console.log(fields.join(' '));
 };

--- a/lib/ralio.js
+++ b/lib/ralio.js
@@ -155,6 +155,69 @@ Ralio.prototype.bulk = function (query, callback) {
   this.request(options, callback);
 };
 
+Ralio.prototype.comments = function (itemID, callback) {
+  var self = this,
+      query = {
+        fetch: 'PostNumber,Text,User',
+        query: '(Artifact.FormattedID = "' + itemID + '")'
+      },
+      ret = {};
+
+  self.artifact(itemID, {
+    fetch: 'FormattedID,Name,Owner,Project,Discussion'
+  }, {}, function(error, item) {
+    if (error !== null) {
+      callback(error);
+    } else {
+      ret.artifact = item;
+      self.bulk({
+        conversationpost: query
+      }, function (error, data) {
+        if (error !== null) {
+          callback(error);
+        } else {
+          var posts = data.conversationpost.Results;
+          posts = _.sortBy(posts, function (s) { return s.PostNumber });
+          ret.comments = posts;
+          callback(null, ret);
+        }
+      });
+    }
+  });
+};
+
+Ralio.prototype.addComment = function (itemID, text, callback) {
+  var self = this,
+      options = {
+        url: self.bulkUrl({"pathname":"/slm/webservice/1.36/conversationpost/create.js"}),
+        method: 'POST',
+        json: {"ConversationPost":{
+          "Text": text
+        }},
+        strictSSL: !Ralio.test
+      };
+
+  self.artifact(itemID, {
+    fetch: 'FormattedID,Name,Owner,Project,Discussion'
+  }, {}, function(error, item) {
+    if (error !== null) {
+      callback(error);
+    } else {
+      options.json.ConversationPost.Artifact = item._ref;
+      options.json.ConversationPost.PostNumber = item.Discussion.length;
+      self.request(options, function(error, data){
+        if (error !== null) {
+          callback(error);
+        } else if (data.CreateResult && data.CreateResult['Object']) {
+          callback(null, data.CreateResult['Object']);
+        } else {
+          callback("Failed to create a new discussion post.", data);
+        }
+      });
+    }
+  });
+};
+
 Ralio.prototype.time = function(taskID, hours, callback) {
   var self = this,
       type = taskID.slice(0,2).toUpperCase(),

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "html": "0.0.7",
     "request": "2.9.203",
     "underscore": "1.3.3",
+    "q": "0.9.0",
     "commander": "1.1.1",
     "colors": "0.6.0-1",
     "cli-table": "0.0.2",


### PR DESCRIPTION
Introduces the `discuss` command, which can be used in one of two ways:

`ralio discuss DE123` will list the discussion posts on the artifact, in order;
`ralio discuss --add "Should be fixed." TA461` will add a comment onto the discussion, and list the new discussion in full.
